### PR TITLE
Fix extension to work when no config is given

### DIFF
--- a/mdx_custom_span_class.py
+++ b/mdx_custom_span_class.py
@@ -60,8 +60,8 @@ class CustomSpanClassPattern(Pattern):
         elem.text = markdown.util.AtomicString(text)
         return elem
 
-def makeExtension(configs=None):
-    return CustomSpanClassExtension(configs=configs)
+def makeExtension(*args, **kwargs):
+    return CustomSpanClassExtension(*args, **kwargs)
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
This fixes an error `'NoneType' object is not iterable` caused when no config is provided.
